### PR TITLE
Update main.cc

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <iostream>
-
+#include <memory>
 #include "raft/raft.h"
 
 using std::cout;
@@ -12,9 +12,10 @@ int main(int argc, char* argv[]) {
 		return 0;
 	}
 
-	Raft *raft = new Raft();
-	raft->createConfig(argv[1]);
-	raft->setRaftNodesByConfig();
-
+	if (auto raft = std::make_shared<Raft>())
+	{
+		raft->createConfig(argv[1]);
+		raft->setRaftNodesByConfig();
+	}
 	return 0;
 }


### PR DESCRIPTION
There was a memory leak where `raft` wasn't getting deleted. It is preferred to now use smart pointers to take care of scope management. In the changed code, we create a shared pointer to a `Raft` object. If we successfully assign a value to `raft`, we go ahead and de-reference it below.